### PR TITLE
Alias `process.platform` as `"windows"` instead of `"win32"` on Windows

### DIFF
--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -1,6 +1,9 @@
 import { suffix } from 'bun:ffi';
 
-const { platform, arch } = process;
+let { platform } = process;
+const { arch } = process;
+
+platform = (platform === "win32") ? "windows" : platform;
 
 async function downloadBinary() {
   // Skip download in CI environments

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -1,6 +1,9 @@
 import { FFIType, dlopen, suffix } from 'bun:ffi';
 
-const { platform, arch } = process;
+let { platform } = process;
+const { arch } = process;
+
+platform = (platform === "win32") : "windows" ? platform;
 
 let filename: string;
 


### PR DESCRIPTION
Fixes #12 and fixes #13 

This PR effectively patches `process.platform` and variables that uses it to report `"windows"` instead of `"win32"`, as the DLL that blipgloss uses is named `windows-amd64` and not `win32-amd64.dll`.

This should be a temporary fix until the next release adjusts the release DLL names, but who knows how that'll go